### PR TITLE
Request for a customizable slidee

### DIFF
--- a/src/sly.js
+++ b/src/sly.js
@@ -61,7 +61,8 @@
 
 		// Frame
 		var $frame = $(frame);
-		var $slidee = $frame.children().eq(0);
+		// var $slidee = $frame.children().eq(0);
+		var $slidee = o.slidee || $frame.children().eq(0);
 		var frameSize = 0;
 		var slideeSize = 0;
 		var pos = {
@@ -2097,6 +2098,8 @@
 
 	// Default options
 	Sly.defaults = {
+		slidee: null, // Selector for a customized slidee, in case there exists one more children inheriting FRAME. Default is SLIDEE, the first child of FRAME
+		
 		horizontal: false, // Switch to horizontal mode.
 
 		// Item based navigation


### PR DESCRIPTION
Hope to see an `options.slidee`, to customize SLIDEE, in case there exists one more children inheriting FRAME, for if not doing so, the default SLIDEE can only be the first/only child of FRAME, which can feel a bit stumbling.